### PR TITLE
Core issue3

### DIFF
--- a/src/test/java/org/bbreak/excella/core/CoreTestUtil.java
+++ b/src/test/java/org/bbreak/excella/core/CoreTestUtil.java
@@ -1,0 +1,27 @@
+package org.bbreak.excella.core;
+
+import java.io.File;
+
+/**
+ * テスト用のユーティリティクラス
+ * 
+ * @since 1.10
+ */
+public class CoreTestUtil {
+
+    /**
+     * テスト用出力ディレクトリを作成する
+     * 
+     * @return
+     */
+    public static String getTestOutputDir() {
+
+        String tempDir = System.getProperty( "user.dir") + "/work/test/";
+        File file = new File( tempDir);
+        if ( !file.exists()) {
+            file.mkdirs();
+        }
+
+        return tempDir;
+    }
+}

--- a/src/test/java/org/bbreak/excella/core/handler/DebugErrorHandlerTest.java
+++ b/src/test/java/org/bbreak/excella/core/handler/DebugErrorHandlerTest.java
@@ -31,6 +31,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.bbreak.excella.core.BookController;
+import org.bbreak.excella.core.CoreTestUtil;
 import org.bbreak.excella.core.WorkbookTest;
 import org.bbreak.excella.core.exception.ParseException;
 import org.junit.Assert;
@@ -58,7 +59,7 @@ public class DebugErrorHandlerTest extends WorkbookTest {
         Workbook workbook = getWorkbook();
         Sheet sheet = workbook.getSheetAt( 0);
 
-        String errorFilePath = "DebugErrorHandlerTest" + System.currentTimeMillis();
+        String errorFilePath = CoreTestUtil.getTestOutputDir() + "DebugErrorHandlerTest" + System.currentTimeMillis();
         if ( workbook instanceof XSSFWorkbook) {
             errorFilePath += BookController.XSSF_SUFFIX;
         } else {

--- a/src/test/java/org/bbreak/excella/core/util/PoiUtilTest.java
+++ b/src/test/java/org/bbreak/excella/core/util/PoiUtilTest.java
@@ -51,6 +51,7 @@ import org.apache.poi.xssf.usermodel.XSSFHyperlink;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.bbreak.excella.core.BookController;
 import org.bbreak.excella.core.CellClone;
+import org.bbreak.excella.core.CoreTestUtil;
 import org.bbreak.excella.core.WorkbookTest;
 import org.bbreak.excella.core.test.util.CheckException;
 import org.bbreak.excella.core.test.util.TestUtil;
@@ -317,7 +318,7 @@ public class PoiUtilTest extends WorkbookTest {
         if ( workbook instanceof XSSFWorkbook) {
             extension = BookController.XSSF_SUFFIX;
         }
-        PoiUtil.writeBook( workbook, "PoiUtilTest" + System.currentTimeMillis() + extension);
+        PoiUtil.writeBook( workbook, CoreTestUtil.getTestOutputDir() + "PoiUtilTest" + System.currentTimeMillis() + extension);
     }
 
     @Test


### PR DESCRIPTION
一部テスト結果については、ファイル指定がない時にカレントディレクトリにエラーファイルを出力する設定の確認になるため、そのままとしている。
