### PR TITLE
fix assembly bin

### DIFF
--- a/src/assembly/bin.xml
+++ b/src/assembly/bin.xml
@@ -12,14 +12,6 @@
       <outputDirectory>/</outputDirectory>
     </file>
     <file>
-      <source>LICENSE</source>
-      <outputDirectory>/</outputDirectory>
-    </file>
-    <file>
-      <source>COPYING</source>
-      <outputDirectory>/</outputDirectory>
-    </file>
-    <file>
       <source>COPYING.LESSER</source>
       <outputDirectory>/</outputDirectory>
     </file>


### PR DESCRIPTION
Remove unnecessary license files
のコミットに伴い、bin.xmlを修正。
不要なファイルの記載を削除