### PR TITLE
getLastRowNumで対象列範囲のみを参照するように変更

### DIFF
--- a/src/main/java/org/bbreak/excella/core/util/PoiUtil.java
+++ b/src/main/java/org/bbreak/excella/core/util/PoiUtil.java
@@ -603,14 +603,12 @@ public final class PoiUtil {
             if ( row == null) {
                 continue;
             }
-            Iterator<Cell> rowIterator = row.iterator();
-            while ( rowIterator.hasNext()) {
-                Cell cell = rowIterator.next();
+            // 対象列範囲だけを直接参照し、不要なセル走査を避ける
+            for ( int j = firstColumnIndex; j <= lastColmunIndex; j++) {
+                Cell cell = row.getCell( j);
                 if ( cell != null) {
-                    if ( firstColumnIndex <= cell.getColumnIndex() && cell.getColumnIndex() <= lastColmunIndex) {
-                        rangeLastRowNum = i;
-                        break;
-                    }
+                    rangeLastRowNum = i;
+                    break;
                 }
             }
             if ( rangeLastRowNum != -1) {

--- a/src/main/java/org/bbreak/excella/core/util/PoiUtil.java
+++ b/src/main/java/org/bbreak/excella/core/util/PoiUtil.java
@@ -603,8 +603,10 @@ public final class PoiUtil {
             if ( row == null) {
                 continue;
             }
-            // 対象列範囲だけを直接参照し、不要なセル走査を避ける
-            for ( int j = firstColumnIndex; j <= lastColmunIndex; j++) {
+            // 対象列範囲だけを直接参照しつつ、範囲外の列番号は未検出扱いにする
+            int startColumnIndex = Math.max( firstColumnIndex, 0);
+            int endColumnIndex = Math.min( lastColmunIndex, row.getLastCellNum() - 1);
+            for ( int j = startColumnIndex; j <= endColumnIndex; j++) {
                 Cell cell = row.getCell( j);
                 if ( cell != null) {
                     rangeLastRowNum = i;

--- a/src/test/java/org/bbreak/excella/core/util/PoiUtilTest.java
+++ b/src/test/java/org/bbreak/excella/core/util/PoiUtilTest.java
@@ -853,12 +853,7 @@ public class PoiUtilTest extends WorkbookTest {
     }
 
     /**
-     * getLastRowNum が、指定した列範囲に対して正しい最終行を返すことを確認する。
-     *
-     * 確認する観点:
-     * - 対象列外のセルは判定に使われないこと
-     * - 対象範囲の末尾列にあるセルも正しく検出できること
-     * - 対象列にセルが存在しない場合は -1 を返すこと
+     * getLastRowNum の判定結果を確認する。
      */
     @Test
     public void testPoiUtil4() {
@@ -886,5 +881,12 @@ public class PoiUtilTest extends WorkbookTest {
         Sheet sheet3 = workbook.createSheet( "getLastRowNum3");
         sheet3.createRow( 4).createCell( 0).setCellValue( "outside");
         assertEquals( -1, PoiUtil.getLastRowNum( sheet3, 19, 19));
+
+        // 範囲外の列番号を含む場合でも、有効な対象範囲だけで判定することを確認する。
+        Sheet sheet4 = workbook.createSheet( "getLastRowNum4");
+        sheet4.createRow( 0).createCell( 0).setCellValue( "value");
+        assertEquals( 0, PoiUtil.getLastRowNum( sheet4, -1, 0));
+        assertEquals( -1, PoiUtil.getLastRowNum( sheet4, -1, -1));
+        assertEquals( 0, PoiUtil.getLastRowNum( sheet4, 0, 1000));
     }
 }

--- a/src/test/java/org/bbreak/excella/core/util/PoiUtilTest.java
+++ b/src/test/java/org/bbreak/excella/core/util/PoiUtilTest.java
@@ -851,4 +851,40 @@ public class PoiUtilTest extends WorkbookTest {
         int lastColNum2 = PoiUtil.getLastColNum( sheet_7);
         assertEquals( 10, lastColNum2);
     }
+
+    /**
+     * getLastRowNum が、指定した列範囲に対して正しい最終行を返すことを確認する。
+     *
+     * 確認する観点:
+     * - 対象列外のセルは判定に使われないこと
+     * - 対象範囲の末尾列にあるセルも正しく検出できること
+     * - 対象列にセルが存在しない場合は -1 を返すこと
+     */
+    @Test
+    public void testPoiUtil4() {
+        Workbook workbook = getWorkbook();
+
+        // 対象列(E列)より下の行に別列(A列)のセルがあっても、
+        // 対象列の最終行は E列に値がある 5 行目になることを確認する。
+        Sheet sheet1 = workbook.createSheet( "getLastRowNum1");
+        sheet1.createRow( 5).createCell( 4).setCellValue( "target");
+        sheet1.createRow( 7).createCell( 0).setCellValue( "outside");
+        assertEquals( 5, PoiUtil.getLastRowNum( sheet1, 4, 4));
+
+        // 対象範囲の末尾列(T列)にセルがある場合でも、
+        // その行を最終行として正しく検出できることを確認する。
+        Sheet sheet2 = workbook.createSheet( "getLastRowNum2");
+        sheet2.createRow( 3);
+        for ( int i = 0; i < 20; i++) {
+            sheet2.getRow( 3).createCell( i).setCellValue( "value_" + i);
+        }
+        sheet2.createRow( 8).createCell( 0).setCellValue( "outside");
+        assertEquals( 3, PoiUtil.getLastRowNum( sheet2, 19, 19));
+
+        // シート内にセルはあっても対象列(T列)にセルがなければ、
+        // 最終行は見つからないため -1 を返すことを確認する。
+        Sheet sheet3 = workbook.createSheet( "getLastRowNum3");
+        sheet3.createRow( 4).createCell( 0).setCellValue( "outside");
+        assertEquals( -1, PoiUtil.getLastRowNum( sheet3, 19, 19));
+    }
 }


### PR DESCRIPTION
## 概要

`PoiUtil.getLastRowNum` は、指定した列範囲の中で一番下にあるセルの行番号を返すメソッドです。

これまでは、各行に存在するセルを順番にたどり、その中に対象列のセルがあるかを調べていました。
この PR では、行内のすべてのセルをたどる代わりに、指定された列範囲だけを直接参照するように変更しています。

また、範囲外の列番号を含む場合は、有効な対象範囲だけで判定するようにし、従来の挙動を維持するようにしています。

## 変更内容

- `PoiUtil.getLastRowNum` の探索方法を見直し
- 範囲外の列番号を含む場合も、従来どおり未検出扱いとなるように調整
- 影響範囲は `excella-core` の `PoiUtil` のみ
- 確認用のテストを `PoiUtilTest` に追加

## 確認した内容

探索方法を変更しても、これまでと同じ結果を返すことを確認するため、以下のケースを追加しました。

- 対象列より下の行に別の列のセルがあっても、対象列の最終行を正しく返すこと
- 対象範囲の右端の列にセルがある場合でも、正しく最終行を返すこと
- 対象列にセルが存在しない場合は `-1` を返すこと
- 範囲外の列番号を含む場合でも、有効な対象範囲だけで判定すること
- `getLastRowNum(sheet, 0, 1000)` のような広い上限値でも、従来どおり判定できること

## 境界値の挙動確認

`upstream/master`、最初の PR 版、現在版で境界値の挙動を比較しました。

確認した結果、現在版では `xls` / `xlsx` ともに `upstream/master` と同じ挙動になることを確認しています。

確認した代表的なケース:

- `getLastRowNum(sheet, -1, 0)`
- `getLastRowNum(sheet, -1, -1)`
- `getLastRowNum(sheet, 0, 1000)`
- `getLastRowNum(sheet, 1000, 2000)`
- `getLastRowNum(sheet, 5, 3)`

## 確認環境

- OS: Windows
- Java: Eclipse Temurin JDK 8
- Maven: ローカルにインストールした Maven 3.9.14

## テスト結果

以下を実行し、手元の Windows 環境で成功しました。

```bash
mvn test